### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
-##Feature Request
+## Feature Request
 If you have any feature request, please [create a GitHub Issue](https://github.com/apegroup/APESuperHUD/issues/new) or make pull requests.
 
-##Reporting Issues
+## Reporting Issues
 A great way to contribute to the project
 is to send a detailed issue when you encounter an problem.
 We always appreciate a well-written, thorough bug report.
@@ -21,7 +21,7 @@ When reporting issues, please include the following:
 
 This information will help us review and fix your issue faster.
 
-##Developer's Certificate of Origin 1.1
+## Developer's Certificate of Origin 1.1
 By making a contribution to this project, I certify that:
 
 - (a) The contribution was created in whole or in part by me and I

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-#APESuperHUD
+# APESuperHUD
 A simple way to display a HUD with a message or progress information in your application.
 
 <p align="center">
   <img src="https://cloud.githubusercontent.com/assets/6545513/19601280/eafb4b50-97a8-11e6-811b-23a6e9d92234.gif" alt="APESuperHUD">
 </p>
 
-##Features
+## Features
 - Simplicity.
 - Customizable. See [Change appearance](#change-appearance).
 - Fully written in Swift.
 - Unit tests.
 
-##Requirements
+## Requirements
 - iOS 8 or later.
 - Xcode 8 (Swift 3.0) or later. For Swift 2.2 use version 0.6
 
-##Installation
-####CocoaPods
+## Installation
+#### CocoaPods
 You can use [CocoaPods](http://cocoapods.org/) to install `APESuperHUD` by adding it to your `Podfile`:
 ```ruby
 platform :ios, '8.0'
@@ -28,31 +28,31 @@ end
 ```
 Note that this requires CocoaPods version 36, and your iOS deployment target to be at least 8.0:
 
-####Carthage
+#### Carthage
 You can use [Carthage](https://github.com/Carthage/Carthage) to install `APESuperHUD` by adding it to your `Cartfile`:
 ```
 github "apegroup/APESuperHUD"
 ```
 
-##Usage
+## Usage
 Don't forget to import.
 ```swift
 import APESuperHUD
 ```
-####Show message HUD
-######With default icon
+#### Show message HUD
+###### With default icon
 ```swift
 APESuperHUD.showOrUpdateHUD(icon: .email, message: "1 new message", duration: 3.0, presentingView: self.view, completion: { _ in
     // Completed
 })
 ```
-######With custom image
+###### With custom image
 ```swift
 APESuperHUD.showOrUpdateHUD(icon: UIImage(named: "apegroup")!, message: "Demo message", duration: 3.0, presentingView: self.view, completion: { _ in
     // Completed
 })
 ```
-######With Title
+###### With Title
 ```swift
 APESuperHUD.showOrUpdateHUD(title: "Title", message: "Demo message", presentingView: self.view) { _ in
     // Completed
@@ -60,26 +60,26 @@ APESuperHUD.showOrUpdateHUD(title: "Title", message: "Demo message", presentingV
 ```
 
 
-####Show HUD with loading indicator
-######With loading text
+#### Show HUD with loading indicator
+###### With loading text
 ```swift
 APESuperHUD.showOrUpdateHUD(loadingIndicator: .standard, message: "Demo loading...", presentingView: self.view)
 ```
-######Without loading text
+###### Without loading text
 ```swift
 APESuperHUD.showOrUpdateHUD(loadingIndicator: .standard, message: "", presentingView: self.view, completion: nil)
 ```
-######With funny loading texts
+###### With funny loading texts
 ```swift
 APESuperHUD.showOrUpdateHUD(loadingIndicator: .standard, funnyMessagesLanguage: .english, presentingView: self.view)
 ```
-####Remove HUD
+#### Remove HUD
 ```swift
 APESuperHUD.removeHUD(animated: true, presentingView: self.view, completion: { _ in
     // Completed
 })
 ```
-####Change appearance
+#### Change appearance
 ```swift
 APESuperHUD.appearance.cornerRadius = 12
 APESuperHUD.appearance.animateInTime = 1.0
@@ -98,8 +98,8 @@ APESuperHUD.appearance.titleFontSize = 22
 APESuperHUD.appearance.messageFontSize = 14
 ```
 
-##Contributing
+## Contributing
 All people are welcome to contribute. See CONTRIBUTING for details.
 
-##License
+## License
 APESuperHUD is released under the MIT license. See LICENSE for details.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
