### PR TITLE
Enabled the modification of the contentMode applied to the iconImageView

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ HUDAppearance.messageFont = UIFont.systemFont(ofSize: 13, weight: .regular)
 /// The title font in the HUD
 HUDAppearance.titleFont = UIFont.systemFont(ofSize: 20, weight: .bold)
 
+/// The content mode used to render the icon
+HUDAppearance.iconContentMode = .scaleToFill
+
 /// The size of the icon inside the HUD
 HUDAppearance.iconSize = CGSize(width: 48, height: 48)
 

--- a/Source/APESuperHUD.swift
+++ b/Source/APESuperHUD.swift
@@ -164,6 +164,7 @@ public class APESuperHUD: UIViewController {
             hudView.clipsToBounds = false
         }
         iconImageView.tintColor = HUDAppearance.iconColor
+        iconImageView.contentMode = HUDAppearance.iconContentMode
         
         messageLabel.font = HUDAppearance.messageFont
         titleLabel.font = HUDAppearance.titleFont

--- a/Source/HudAppearance.swift
+++ b/Source/HudAppearance.swift
@@ -73,6 +73,9 @@ public struct HUDAppearance {
     /// The title font in the HUD
     public static var titleFont = UIFont.systemFont(ofSize: 20, weight: .bold)
     
+    /// The content mode used to render the icon
+    public static var iconContentMode: UIViewContentMode = .scaleToFill
+    
     /// The size of the icon inside the HUD
     public static var iconSize = CGSize(width: 48, height: 48)
     


### PR DESCRIPTION
This PR enabled modifying the `contentMode` applied to the `UIImageView` used to display the icon. I found out that it makes my life easier because using `.scaleAspectFit` makes almost every icon look good, no matter the size, and it allows me to not having to specify the exact size for the icon.